### PR TITLE
Fixed path extraction for Windows and OSX 

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -77,7 +77,7 @@ module.exports =
         return unless grammar and grammar.scopeName is 'source.asciidoc'
 
         # Native image support
-        if @isImage clipboard
+        if @isImage()
           event.stopImmediatePropagation()
           imageFactory.createImage activeEditor, clipboard
             .then successHandler
@@ -85,17 +85,7 @@ module.exports =
 
         # Image URL support
         else if atom.config.get 'asciidoc-image-helper.enableUrlSupport'
-          clipboardText = clipboard.readText()
-          console.log clipboardText
-
-          # windows specific
-          windowsFilePattern = /^file:[\/]{2,3}(.*)/
-          windowsPathPattern = /^\"(.*)\"$/
-          if clipboardText.match windowsFilePattern
-            clipboardText = windowsFilePattern.exec(clipboardText)[1]
-
-          if clipboardText.match windowsPathPattern
-            clipboardText = windowsPathPattern.exec(clipboardText)[1]
+          clipboardText = @readClipboardText()
 
           if @isImageUrl clipboardText
             event.stopImmediatePropagation()
@@ -103,12 +93,27 @@ module.exports =
               .then successHandler
               .catch errorHandler
 
-  isImage: (clipboard) ->
+  isImage: ->
     not clipboard.readImage().isEmpty()
 
   isImageUrl: (clipboardText) ->
     imageExtensions = atom.config.get 'asciidoc-image-helper.imageExtensions'
     clipboardText?.length? and path.extname(clipboardText) in imageExtensions and new File(clipboardText).existsSync()
+
+  readClipboardText: ->
+    clipboardText = clipboard.readText()
+
+    # windows specific
+    windowsFilePattern = /^file:[\/]{2,3}(.*)$/
+    if clipboardText.match windowsFilePattern
+      clipboardText = windowsFilePattern.exec(clipboardText)[1]
+
+    # windows specific
+    windowsPathPattern = /^\"(.*)\"$/
+    if clipboardText.match windowsPathPattern
+      clipboardText = windowsPathPattern.exec(clipboardText)[1]
+
+    clipboardText
 
   onDidInsert: (callback) ->
     @emitter.on 'did-image-insert', callback

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -89,8 +89,8 @@ module.exports =
           console.log clipboardText
 
           # windows specific
-          windowsFilePattern = /file:[\/]{2,3}(.*)/
-          windowsPathPattern = /\"(.*)\"/
+          windowsFilePattern = /^file:[\/]{2,3}(.*)/
+          windowsPathPattern = /^\"(.*)\"$/
           if clipboardText.match windowsFilePattern
             clipboardText = windowsFilePattern.exec(clipboardText)[1]
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -85,7 +85,12 @@ module.exports =
 
         # Image URL support
         else if atom.config.get 'asciidoc-image-helper.enableUrlSupport'
-          clipboardText = clipboard.readText().split(/file:[\/]{2,3}/).join('').replace /^\"|\"$/g, ''
+          clipboardText = clipboard.readText()
+
+          # windows specific
+          windowsPattern = /^\"file:[\/]{2,3}(.*)\"$/
+          if clipboardText.match windowsPattern
+            clipboardText = windowsPattern.exec(clipboardText)[1]
 
           if @isImageUrl clipboardText
             event.stopImmediatePropagation()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -86,11 +86,16 @@ module.exports =
         # Image URL support
         else if atom.config.get 'asciidoc-image-helper.enableUrlSupport'
           clipboardText = clipboard.readText()
+          console.log clipboardText
 
           # windows specific
-          windowsPattern = /^\"file:[\/]{2,3}(.*)\"$/
-          if clipboardText.match windowsPattern
-            clipboardText = windowsPattern.exec(clipboardText)[1]
+          windowsFilePattern = /file:[\/]{2,3}(.*)/
+          windowsPathPattern = /\"(.*)\"/
+          if clipboardText.match windowsFilePattern
+            clipboardText = windowsFilePattern.exec(clipboardText)[1]
+
+          if clipboardText.match windowsPathPattern
+            clipboardText = windowsPathPattern.exec(clipboardText)[1]
 
           if @isImageUrl clipboardText
             event.stopImmediatePropagation()

--- a/spec/main-url-support-spec.coffee
+++ b/spec/main-url-support-spec.coffee
@@ -47,7 +47,7 @@ describe 'URL with AsciiDoc Image helper should', ->
     expect(editor.getSelectedText()).toMatch /^foobar$/
     editor.delete()
 
-    imageUrl = 'file:///' + path.join(__dirname, 'fixtures', imageName) + ''
+    imageUrl = 'file:///' + path.join(__dirname, 'fixtures', imageName)
     clipboard.writeText imageUrl
     atom.commands.dispatch workspaceElement, 'core:paste'
 

--- a/spec/main-url-support-spec.coffee
+++ b/spec/main-url-support-spec.coffee
@@ -33,7 +33,7 @@ describe 'URL with AsciiDoc Image helper should', ->
     temp.cleanupSync()
 
 
-  it 'create a link and store the image in a directory when image folder append to link and URL in "windows style" and use the default directory', ->
+  it 'create a link and store the image in a directory when image folder append to link and URL in "file" format and use the default directory', ->
     called = false
     asciiDocimageHelper.onDidInsert -> called = true
 
@@ -47,7 +47,36 @@ describe 'URL with AsciiDoc Image helper should', ->
     expect(editor.getSelectedText()).toMatch /^foobar$/
     editor.delete()
 
-    imageUrl = '"file:///' + path.join(__dirname, 'fixtures', imageName) + '"'
+    imageUrl = 'file:///' + path.join(__dirname, 'fixtures', imageName) + ''
+    clipboard.writeText imageUrl
+    atom.commands.dispatch workspaceElement, 'core:paste'
+
+    waitsFor 'markup insertion', -> called
+
+    runs ->
+      editor.selectAll()
+      expect(editor.getSelectedText()).toMatch /image::images(\/|\\)logo-atom\.png\[\]/
+      imagesFolder = atom.config.get 'asciidoc-image-helper.imagesFolder'
+      stat = fs.statSync path.join directory, imagesFolder, imageName
+      expect(stat).toBeDefined()
+      expect(stat.size).toBe 6258
+
+
+  it 'create a link and store the image in a directory when image folder append to link and URL in quoted string and use the default directory', ->
+    called = false
+    asciiDocimageHelper.onDidInsert -> called = true
+
+    atom.config.set 'asciidoc-image-helper.appendImagesFolder', true # Default
+    atom.config.set 'asciidoc-image-helper.enableUrlSupport', true
+
+    editor = atom.workspace.getActiveTextEditor()
+    expect(editor.getPath()).toMatch /^.*(\/|\\)foobar\.adoc$/
+
+    editor.selectAll()
+    expect(editor.getSelectedText()).toMatch /^foobar$/
+    editor.delete()
+
+    imageUrl = '"' + path.join(__dirname, 'fixtures', imageName) + '"'
     clipboard.writeText imageUrl
     atom.commands.dispatch workspaceElement, 'core:paste'
 

--- a/spec/main-url-support-spec.coffee
+++ b/spec/main-url-support-spec.coffee
@@ -51,7 +51,7 @@ describe 'URL with AsciiDoc Image helper should', ->
     clipboard.writeText imageUrl
     atom.commands.dispatch workspaceElement, 'core:paste'
 
-    waitsFor 'markup insertion', -> called is true
+    waitsFor 'markup insertion', -> called
 
     runs ->
       editor.selectAll()


### PR DESCRIPTION
Corrects regex for file:\\ pattern from #12 and adds in a pattern for matching quoted path string.
